### PR TITLE
Remove extra double quote from the detailed description

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ LABEL org.opencontainers.image.title="Dive" \
     org.opencontainers.image.vendor="Docker Inc." \
     com.docker.desktop.extension.api.version="0.3.0" \
     com.docker.extension.screenshots='[{"alt":"main page", "url":"https://github.com/prakhar1989/dive-in/blob/main/screenshots/1.png?raw=true"}, {"alt":"start containers", "url":"https://github.com/prakhar1989/dive-in/blob/main/screenshots/2.png?raw=true"}]' \
-    com.docker.extension.detailed-description="<p><h1>Dive In</h1>”Explore docker images, layer contents, and discover ways to shrink the size of your Docker/OCI image.</p>" \
+    com.docker.extension.detailed-description="<p><h1>Dive In</h1>Explore docker images, layer contents, and discover ways to shrink the size of your Docker/OCI image.</p>" \
     com.docker.desktop.extension.icon="https://raw.githubusercontent.com/prakhar1989/dive-in/main/scuba.svg" \
     com.docker.extension.publisher-url="https://prakhar.me" \
     com.docker.extension.categories="utility-tools" \


### PR DESCRIPTION
Hi Prakhar,

there was an extra double quote in the detailed description, this PR removes it.

<img width="665" alt="Screenshot 2022-12-08 at 11 09 39" src="https://user-images.githubusercontent.com/212269/206419688-bfb99889-52a3-44f2-b9ef-041df8f68731.png">
 