### PR TITLE
Change image name to match the one in metadata.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY ui /ui
 RUN npm run build
 
 FROM alpine
-LABEL org.opencontainers.image.title="Dive" \
+LABEL org.opencontainers.image.title="Dive In" \
     org.opencontainers.image.description="Explore docker images, layer contents, and discover ways to shrink the size of your Docker/OCI image." \
     org.opencontainers.image.vendor="Docker Inc." \
     com.docker.desktop.extension.api.version="0.3.0" \


### PR DESCRIPTION
I suggest the name of the extension is the same in the Marketplace (the title in the Dockerfile) and in the left menu (the title in metadata.json). 