### PR TITLE
Use TS-optional chaining to fix access error

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -45,7 +45,7 @@ export function App() {
 
   const checkDiveInstallation = async () => {
     const result = (await readImages()).some((i) =>
-      i.RepoTags[0].includes(DIVE_DOCKER_IMAGE)
+      i.RepoTags[0]?.includes(DIVE_DOCKER_IMAGE)
     );
     setDiveInstalled(result);
   };


### PR DESCRIPTION
Fixes #6  

The proposed change uses TypeScript's optional chaining mechanism to only check for inclusion of DRIVE_DOCKER_IMAGE when RepoTags[0] is not undefined. This should remove the error users have when there's an Image without tags.